### PR TITLE
Style reset password under the hood

### DIFF
--- a/dj_theme/templates/dj_theme/partials/logged_in_forms/form_errors.html
+++ b/dj_theme/templates/dj_theme/partials/logged_in_forms/form_errors.html
@@ -1,0 +1,14 @@
+{% load allauth i18n %}
+{% if form.errors %}
+<h2 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
+  {% trans "Please correct the following errors:" %}
+</h2>
+
+<ul class="max-w-md space-y-1 text-gray-500 list-disc list-inside dark:text-gray-400">
+  {% for key, value in form.errors.items %}
+    <li id="password_error_{{key}}">
+      {{ value.as_text|cut:"*" }}
+    </li>
+  {% endfor %}
+</ul>
+{% endif %}

--- a/dj_theme/templates/dj_theme/partials/non_logged_in_forms/field.html
+++ b/dj_theme/templates/dj_theme/partials/non_logged_in_forms/field.html
@@ -1,0 +1,58 @@
+{% load i18n %}
+<div>
+  {% if field.field.widget.input_type == "password" %}
+    <label for="password_{{ field.auto_id }}" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+      {{ field.label }}
+    </label>
+
+    <input type="password"
+            name="{{ field.name }}"
+            id="password_{{ field.auto_id }}"
+            placeholder="{{ field.field.widget.attrs.placeholder|default:'••••••••' }}"
+            class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+            {% if field.field.widget.attrs.autocomplete %} autocomplete="{{ field.field.widget.attrs.autocomplete }}" {% endif %}
+            required="">
+  {% elif field.field.widget.input_type == "email" %}
+    <label for="email_{{ field.auto_id }}" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+      {{ field.label }}
+    </label>
+
+    <input type="{{ field.field.widget.input_type }}"
+            name="{{ field.name }}"
+            id="email_{{ field.auto_id }}"
+            class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+            placeholder="{{ field.field.widget.attrs.placeholder|default:'name@provider.com' }}"
+            required="">
+  {% elif field.field.widget.input_type == "checkbox" %}{# Used for "Remember me" #}
+    <div class="flex items-center justify-between">
+        <div class="flex items-start">
+            <div class="flex items-center h-5">
+              <input type="checkbox"
+                      id="remember_{{ field.auto_id }}"
+                      aria-describedby="remember"
+                      class="w-4 h-4 border border-gray-300 rounded bg-gray-50 focus:ring-3 focus:ring-primary-300 dark:bg-gray-700 dark:border-gray-600 dark:focus:ring-primary-600 dark:ring-offset-gray-800">
+            </div>
+            <div class="ml-3 text-sm">
+              <label for="remember_{{ field.auto_id }}"
+                      class="text-gray-500 dark:text-gray-300">
+                {{ field.label }}
+              </label>
+            </div>
+        </div>
+
+        <a href="{% url 'account_reset_password' %}" class="text-sm font-medium text-primary-600 hover:underline dark:text-primary-500">
+          {% trans "Forgot password?" %}
+        </a>
+    </div>
+  {% else %}{# Default, no styling #}
+    {{ field }}
+  {% endif %}
+
+  {% if field.help_text %}
+    <small class="text-gray-500 dark:text-gray-400">{{ field.help_text }}</small>
+  {% endif %}
+
+  {% for error in field.errors %}
+    <p class="text-red-500 dark:text-red-400">{{ error }}</p>
+  {% endfor %}
+</div>

--- a/dj_users/templates/account/partials/field.html
+++ b/dj_users/templates/account/partials/field.html
@@ -1,0 +1,50 @@
+{% load allauth %}
+<label for="{{ field.id_for_label }}" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+  {{ field.label }}
+</label>
+{% if field.type == "textarea" %}
+  <textarea {% if field.required %}required{% endif %}
+            {% if field.rows %}rows="{{ field.rows }}"{% endif %}
+            {% if field.disabled %}disabled{% endif %}
+            {% if field.readonly %}readonly{% endif %}
+            {% if field.checked %}checked{% endif %}
+            {% if field.name %}name="{{ field.name }}"{% endif %}
+            {% if field.id %}id="{{ field.id }}"{% endif %}
+            {% if field.placeholder %}placeholder="{{ field.placeholder }}"{% endif %}
+            {% if field.errors %}
+              class="bg-red-50 border border-red-500 text-red-900 placeholder-red-700 text-sm rounded-lg focus:ring-red-500 dark:bg-gray-700 focus:border-red-500 block w-full p-2.5 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500"
+            {% else %}
+              class="shadow-sm bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:shadow-sm-light"
+            {% endif %}
+            >{% slot value %}{% endslot %}</textarea>
+{% else %}
+  <input {% if field.required %}required{% endif %}
+         {% if field.disabled %}disabled{% endif %}
+         {% if field.readonly %}readonly{% endif %}
+         {% if field.checked %}checked{% endif %}
+         {% if field.name %}name="{{ field.name }}"{% endif %}
+         {% if field.id %}id="{{ field.id }}"{% endif %}
+         {% if field.placeholder %}placeholder="{{ field.placeholder }}"{% endif %}
+         {% if field.autocomplete %}autocomplete="{{ field.autocomplete }}"{% endif %}
+         value="{{ field.value|default_if_none:"" }}"
+         type="{{ field.type }}"
+         {% if field.errors %}
+          class="bg-red-50 border border-red-500 text-red-900 placeholder-red-700 text-sm rounded-lg focus:ring-red-500 dark:bg-gray-700 focus:border-red-500 block w-full p-2.5 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500"
+         {% else %}
+          class="shadow-sm bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:shadow-sm-light"
+         {% endif %}
+         >
+{% endif %}
+
+{% if field.errors %}
+<p class="text-red-500 text-xs italic">
+  {% for error in field.errors %}
+    {{ error }}<br />
+  {% endfor %}
+</p>
+{% endif %}
+
+{% if slots.help_text %}
+  <span>{% slot help_text %}</span>
+  {% endslot %}
+{% endif %}

--- a/dj_users/templates/account/password_change.html
+++ b/dj_users/templates/account/password_change.html
@@ -36,19 +36,7 @@
 
         {% url 'account_change_password' as action_url %}
 
-        {% if form.errors %}
-          <h2 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
-            {% trans "Please correct the following errors:" %}
-          </h2>
-
-          <ul class="max-w-md space-y-1 text-gray-500 list-disc list-inside dark:text-gray-400">
-            {% for key, value in form.errors.items %}
-              <li id="password_error_{{key}}">
-                {{ value.as_text|cut:"*" }}
-              </li>
-            {% endfor %}
-          </ul>
-        {% endif %}
+        {% include "dj_theme/partials/logged_in_forms/form_errors.html" %}
 
         <form method="post" action="{{ action_url }}" class="space-y-4 max-w-sm mx-auto md:mx-2">
           {% csrf_token %}

--- a/dj_users/templates/account/password_change.html
+++ b/dj_users/templates/account/password_change.html
@@ -38,64 +38,67 @@
 
         {% include "dj_theme/partials/logged_in_forms/form_errors.html" %}
 
-        <form method="post" action="{{ action_url }}" class="space-y-4 max-w-sm mx-auto md:mx-2">
-          {% csrf_token %}
+        {% element form form=form method="post" action=action_url tags="authenticated,change_password" %}
+          {% slot body %}
+            {% csrf_token %}
 
-          <div class="space-y-2">
-            {% for field in form %}
-              <div>
-                <label for="{{ field.id_for_label }}" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-                  {{ field.label }}
-                </label>
+            <div class="space-y-2">
+              {% for field in form %}
+                <div>
+                  <label for="{{ field.id_for_label }}" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                    {{ field.label }}
+                  </label>
 
-                <input {% if field.required %}required{% endif %}
-                  {% if field.disabled %}disabled{% endif %}
-                  {% if field.readonly %}readonly{% endif %}
-                  {% if field.checked %}checked{% endif %}
-                  {% if field.name %}name="{{ field.name }}"{% endif %}
-                  {% if field.id %}id="{{ field.id }}"{% endif %}
-                  {% if field.placeholder %}placeholder="{{ field.placeholder }}"{% endif %}
-                  {% if field.autocomplete %}autocomplete="{{ field.autocomplete }}"{% endif %}
-                  value="{{ field.value|default_if_none:"" }}"
+                  <input {% if field.required %}required{% endif %}
+                    {% if field.disabled %}disabled{% endif %}
+                    {% if field.readonly %}readonly{% endif %}
+                    {% if field.checked %}checked{% endif %}
+                    {% if field.name %}name="{{ field.name }}"{% endif %}
+                    {% if field.id %}id="{{ field.id }}"{% endif %}
+                    {% if field.placeholder %}placeholder="{{ field.placeholder }}"{% endif %}
+                    {% if field.autocomplete %}autocomplete="{{ field.autocomplete }}"{% endif %}
+                    value="{{ field.value|default_if_none:"" }}"
+                    {% if field.errors %}
+                      class="bg-red-50 border border-red-500 text-red-900 placeholder-red-700 text-sm rounded-lg focus:ring-red-500 dark:bg-gray-700 focus:border-red-500 block w-full p-2.5 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500"
+                    {% else %}
+                      class="shadow-sm bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:shadow-sm-light"
+                    {% endif %}
+                    type="{% if field.type %}{{ field.type }}{% else %}password{% endif %}">
+
                   {% if field.errors %}
-                    class="bg-red-50 border border-red-500 text-red-900 placeholder-red-700 text-sm rounded-lg focus:ring-red-500 dark:bg-gray-700 focus:border-red-500 block w-full p-2.5 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500"
-                  {% else %}
-                    class="shadow-sm bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:shadow-sm-light"
+                    <p class="text-red-500 text-xs italic">
+                      {% for error in field.errors %}
+                        {{ error }}<br />
+                      {% endfor %}
+                    </p>
                   {% endif %}
-                  type="{% if field.type %}{{ field.type }}{% else %}password{% endif %}">
 
-                {% if field.errors %}
-                  <p class="text-red-500 text-xs italic">
-                    {% for error in field.errors %}
-                      {{ error }}<br />
-                    {% endfor %}
-                  </p>
-                {% endif %}
+                  {% if field.help_text %}
+                    <div class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                      {{ field.help_text }}
+                    </div>
+                  {% endif %}
+                </div>
+              {% endfor %}
+            </div>
+          {% endslot %}
 
-                {% if field.help_text %}
-                  <div class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-                    {{ field.help_text }}
-                  </div>
-                {% endif %}
-              </div>
-            {% endfor %}
-          </div>
+          {% slot actions %}
+            <div class="flex justify-between items-center">
+              <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md">
+                {% trans "Change Password" %}
+              </button>
 
-          <div class="flex justify-between items-center">
-            <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md">
-              {% trans "Change Password" %}
-            </button>
+              {% comment %}
+                Commented out as corresponding template has not been styled yet.
 
-            {% comment %}
-              Commented out as corresponding template has not been styled yet.
-
-              <a href="{% url 'account_reset_password' %}" class="text-indigo-600 hover:text-indigo-700">
-                {% trans "Forgot Password?" %}
-              </a>
-            {% endcomment %}
-          </div>
-        </form>
-
+                <a href="{% url 'account_reset_password' %}" class="text-indigo-600 hover:text-indigo-700">
+                  {% trans "Forgot Password?" %}
+                </a>
+              {% endcomment %}
+            </div>
+          {% endslot %}
+        {% endelement %}
 
         <div class="flex justify-between items-center space-y-4 md:mx-2 my-5">
           <a href="{% url 'dj_dashboard:dashboard' %}" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md">

--- a/dj_users/templates/account/password_reset.html
+++ b/dj_users/templates/account/password_reset.html
@@ -1,30 +1,11 @@
-{% extends "account/base_entrance.html" %}
-{% load i18n allauth account %}
-{% block head_title %}
-    {% trans "Password Reset" %}
-{% endblock head_title %}
-{% block content %}
-    {% element h1 %}
-        {% trans "Password Reset" %}
-    {% endelement %}
-    {% if user.is_authenticated %}
-        {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
-    <p>
-        {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
-    </p>
-    {% url 'account_reset_password' as reset_url %}
-    {% element form form=form method="post" action=reset_url %}
-        {% slot body %}
-            {% csrf_token %}
-            {% element fields form=form %}
-            {% endelement %}
-        {% endslot %}
-        {% slot actions %}
-            {% element button type="submit" %}
-                {% trans 'Reset My Password' %}
-            {% endelement %}
-        {% endslot %}
-    {% endelement %}
-    <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
-{% endblock content %}
+{% comment %}
+    In this place we should check if email dispatches are set up or not.
+    If not then we should show a message to the user explaining that we cannot
+    send the email and that they should contact the admin.
+{% endcomment %}
+
+{% if user.is_authenticated %}
+  {% include "account/password_reset_logged_in.html" %}
+{% else %}
+  {% include "account/password_reset_not_logged_in.html" %}
+{% endif %}

--- a/dj_users/templates/account/password_reset_done.html
+++ b/dj_users/templates/account/password_reset_done.html
@@ -1,18 +1,37 @@
-{% extends "account/base_entrance.html" %}
+{% extends "dj_theme/base.html" %}
+{% comment %}
+  Version here based on: https://flowbite.com/blocks/marketing/login/
+{% endcomment %}
+
 {% load i18n %}
 {% load allauth %}
 {% load account %}
 {% block head_title %}
     {% trans "Password Reset" %}
 {% endblock head_title %}
+
 {% block content %}
-    {% element h1 %}
+  {% include "dj_theme/header.html" %}
+
+  <section class="bg-gray-50 dark:bg-gray-900">
+    <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
+      <h1 class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
         {% trans "Password Reset" %}
-    {% endelement %}
-    {% if user.is_authenticated %}
-        {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
-    <p>
-        {% blocktrans %}We have sent you an email. If you have not received it please check your spam folder. Otherwise contact us if you do not receive it in a few minutes.{% endblocktrans %}
-    </p>
+      </h1>
+
+      <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
+        <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
+          {% if user.is_authenticated %}
+            {% include "account/snippets/already_logged_in.html" %}
+          {% endif %}
+
+          <p>
+            {% blocktrans %}
+              We have sent you an email. If you have not received it please check your spam folder. Otherwise contact us if you do not receive it in a few minutes.
+            {% endblocktrans %}
+          </p>
+        </div>
+      </div>
+    </div>
+    </section>
 {% endblock content %}

--- a/dj_users/templates/account/password_reset_logged_in.html
+++ b/dj_users/templates/account/password_reset_logged_in.html
@@ -24,8 +24,9 @@
         {% element form form=form method="post" action=reset_url tags="authenticated,change_password" %}
           {% slot body %}
             {% csrf_token %}
-            {% element fields form=form %}
-            {% endelement %}
+            {% for field in form %}
+              {% include "account/partials/field.html" %}
+            {% endfor %}
           {% endslot %}
 
           {% slot actions %}

--- a/dj_users/templates/account/password_reset_logged_in.html
+++ b/dj_users/templates/account/password_reset_logged_in.html
@@ -15,9 +15,6 @@
             {% trans "Password Reset" %}
         {% endelement %}
 
-        {% if user.is_authenticated %}
-            {% include "account/snippets/already_logged_in.html" %}
-        {% endif %}
         <p>
             {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
         </p>

--- a/dj_users/templates/account/password_reset_logged_in.html
+++ b/dj_users/templates/account/password_reset_logged_in.html
@@ -15,23 +15,31 @@
             {% trans "Password Reset" %}
         {% endelement %}
 
-        <p>
-            {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
+        <p class="mb-3 text-gray-500 dark:text-gray-400">
+          {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
         </p>
+
         {% url 'account_reset_password' as reset_url %}
-        {% element form form=form method="post" action=reset_url %}
-            {% slot body %}
-                {% csrf_token %}
-                {% element fields form=form %}
-                {% endelement %}
-            {% endslot %}
-            {% slot actions %}
-                {% element button type="submit" %}
-                    {% trans 'Reset My Password' %}
-                {% endelement %}
-            {% endslot %}
-        {% endelement %}
-        <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+
+        <form method="post" action="{{ action_url }}" class="space-y-4 max-w-sm mx-auto md:mx-2">
+          {% csrf_token %}
+
+          {% element fields form=form %}
+          {% endelement %}
+
+          <div class="flex justify-between items-center">
+            <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md">
+              {% trans 'Reset My Password' %}
+            </button>
+          </div>
+        </form>
+
+        <p class="mb-3 text-gray-500 dark:text-gray-400">
+          {% blocktrans %}
+            Please contact us if you have any trouble resetting your password.
+          {% endblocktrans %}
+        </p>
+      </div>
     </div>
   </main>
 {% endblock logged_in_content %}

--- a/dj_users/templates/account/password_reset_logged_in.html
+++ b/dj_users/templates/account/password_reset_logged_in.html
@@ -1,30 +1,40 @@
-{% extends "account/base_entrance.html" %}
+{% extends "dj_theme/base_logged_in.html" %}
 {% load i18n allauth account %}
+
 {% block head_title %}
     {% trans "Password Reset" %}
 {% endblock head_title %}
-{% block content %}
-    {% element h1 %}
-        {% trans "Password Reset" %} - Logged in
-    {% endelement %}
-    {% if user.is_authenticated %}
-        {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
-    <p>
-        {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
-    </p>
-    {% url 'account_reset_password' as reset_url %}
-    {% element form form=form method="post" action=reset_url %}
-        {% slot body %}
-            {% csrf_token %}
-            {% element fields form=form %}
-            {% endelement %}
-        {% endslot %}
-        {% slot actions %}
-            {% element button type="submit" %}
-                {% trans 'Reset My Password' %}
-            {% endelement %}
-        {% endslot %}
-    {% endelement %}
-    <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
-{% endblock content %}
+
+{% block logged_in_content %}
+  <main>
+    <div class="px-4 pt-6">
+      {% include "dj_theme/messages.html" %}
+
+      <div class="grid grid-cols-1 mb-4 xl:grid-cols-1 xl:gap-4">
+        {% element h5 %}
+            {% trans "Password Reset" %}
+        {% endelement %}
+
+        {% if user.is_authenticated %}
+            {% include "account/snippets/already_logged_in.html" %}
+        {% endif %}
+        <p>
+            {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
+        </p>
+        {% url 'account_reset_password' as reset_url %}
+        {% element form form=form method="post" action=reset_url %}
+            {% slot body %}
+                {% csrf_token %}
+                {% element fields form=form %}
+                {% endelement %}
+            {% endslot %}
+            {% slot actions %}
+                {% element button type="submit" %}
+                    {% trans 'Reset My Password' %}
+                {% endelement %}
+            {% endslot %}
+        {% endelement %}
+        <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+    </div>
+  </main>
+{% endblock logged_in_content %}

--- a/dj_users/templates/account/password_reset_logged_in.html
+++ b/dj_users/templates/account/password_reset_logged_in.html
@@ -23,7 +23,7 @@
 
         {% include "dj_theme/partials/logged_in_forms/form_errors.html" %}
 
-        {% element form form=form method="post" action=reset_url tags="authenticated,change_password" %}
+        {% element form form=form method="post" action=reset_url tags="authenticated,reset_password" %}
           {% slot body %}
             {% csrf_token %}
             {% for field in form %}

--- a/dj_users/templates/account/password_reset_logged_in.html
+++ b/dj_users/templates/account/password_reset_logged_in.html
@@ -21,6 +21,8 @@
 
         {% url 'account_reset_password' as reset_url %}
 
+        {% include "dj_theme/partials/logged_in_forms/form_errors.html" %}
+
         {% element form form=form method="post" action=reset_url tags="authenticated,change_password" %}
           {% slot body %}
             {% csrf_token %}

--- a/dj_users/templates/account/password_reset_logged_in.html
+++ b/dj_users/templates/account/password_reset_logged_in.html
@@ -1,0 +1,30 @@
+{% extends "account/base_entrance.html" %}
+{% load i18n allauth account %}
+{% block head_title %}
+    {% trans "Password Reset" %}
+{% endblock head_title %}
+{% block content %}
+    {% element h1 %}
+        {% trans "Password Reset" %} - Logged in
+    {% endelement %}
+    {% if user.is_authenticated %}
+        {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
+    <p>
+        {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
+    </p>
+    {% url 'account_reset_password' as reset_url %}
+    {% element form form=form method="post" action=reset_url %}
+        {% slot body %}
+            {% csrf_token %}
+            {% element fields form=form %}
+            {% endelement %}
+        {% endslot %}
+        {% slot actions %}
+            {% element button type="submit" %}
+                {% trans 'Reset My Password' %}
+            {% endelement %}
+        {% endslot %}
+    {% endelement %}
+    <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+{% endblock content %}

--- a/dj_users/templates/account/password_reset_logged_in.html
+++ b/dj_users/templates/account/password_reset_logged_in.html
@@ -21,18 +21,21 @@
 
         {% url 'account_reset_password' as reset_url %}
 
-        <form method="post" action="{{ action_url }}" class="space-y-4 max-w-sm mx-auto md:mx-2">
-          {% csrf_token %}
+        {% element form form=form method="post" action=reset_url tags="authenticated,change_password" %}
+          {% slot body %}
+            {% csrf_token %}
+            {% element fields form=form %}
+            {% endelement %}
+          {% endslot %}
 
-          {% element fields form=form %}
-          {% endelement %}
-
-          <div class="flex justify-between items-center">
-            <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md">
-              {% trans 'Reset My Password' %}
-            </button>
-          </div>
-        </form>
+          {% slot actions %}
+            <div class="flex justify-between items-center">
+              <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md">
+                {% trans 'Reset My Password' %}
+              </button>
+            </div>
+          {% endslot %}
+        {% endelement %}
 
         <p class="mb-3 text-gray-500 dark:text-gray-400">
           {% blocktrans %}

--- a/dj_users/templates/account/password_reset_not_logged_in.html
+++ b/dj_users/templates/account/password_reset_not_logged_in.html
@@ -1,0 +1,30 @@
+{% extends "account/base_entrance.html" %}
+{% load i18n allauth account %}
+{% block head_title %}
+    {% trans "Password Reset" %}
+{% endblock head_title %}
+{% block content %}
+    {% element h1 %}
+        {% trans "Password Reset" %} - NOT Logged in
+    {% endelement %}
+    {% if user.is_authenticated %}
+        {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
+    <p>
+        {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
+    </p>
+    {% url 'account_reset_password' as reset_url %}
+    {% element form form=form method="post" action=reset_url %}
+        {% slot body %}
+            {% csrf_token %}
+            {% element fields form=form %}
+            {% endelement %}
+        {% endslot %}
+        {% slot actions %}
+            {% element button type="submit" %}
+                {% trans 'Reset My Password' %}
+            {% endelement %}
+        {% endslot %}
+    {% endelement %}
+    <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+{% endblock content %}

--- a/dj_users/templates/account/password_reset_not_logged_in.html
+++ b/dj_users/templates/account/password_reset_not_logged_in.html
@@ -18,30 +18,34 @@
         {% trans "Password Reset" %}
       </h1>
 
-      <p>
-        {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
-      </p>
+      <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
+        <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
+          <p>
+            {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
+          </p>
 
-      {% url 'account_reset_password' as reset_url %}
+          {% url 'account_reset_password' as reset_url %}
 
-      {% element form form=form method="post" action=reset_url %}
-          {% slot body %}
+          {% element form form=form method="post" action=reset_url %}
+            {% slot body %}
               {% csrf_token %}
               {% element fields form=form %}
               {% endelement %}
-          {% endslot %}
-          {% slot actions %}
+            {% endslot %}
+            {% slot actions %}
               {% element button type="submit" %}
-                  {% trans 'Reset My Password' %}
+                {% trans 'Reset My Password' %}
               {% endelement %}
-          {% endslot %}
-      {% endelement %}
+            {% endslot %}
+          {% endelement %}
 
-      <p>
-        {% blocktrans %}
-          Please contact us if you have any trouble resetting your password.
-        {% endblocktrans %}
-      </p>
+          <p>
+            {% blocktrans %}
+              Please contact us if you have any trouble resetting your password.
+            {% endblocktrans %}
+          </p>
+        </div>
+      </div>
     </div>
   </section>
 {% endblock content %}

--- a/dj_users/templates/account/password_reset_not_logged_in.html
+++ b/dj_users/templates/account/password_reset_not_logged_in.html
@@ -1,30 +1,47 @@
-{% extends "account/base_entrance.html" %}
+{% extends "dj_theme/base.html" %}
+{% comment %}
+  Version here based on: https://flowbite.com/blocks/marketing/login/
+{% endcomment %}
+
 {% load i18n allauth account %}
+
 {% block head_title %}
     {% trans "Password Reset" %}
 {% endblock head_title %}
+
 {% block content %}
-    {% element h1 %}
-        {% trans "Password Reset" %} - NOT Logged in
-    {% endelement %}
-    {% if user.is_authenticated %}
-        {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
-    <p>
+  {% include "dj_theme/header.html" %}
+
+  <section class="bg-gray-50 dark:bg-gray-900">
+    <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
+      <h1 class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
+        {% trans "Password Reset" %}
+      </h1>
+
+      <p>
         {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
-    </p>
-    {% url 'account_reset_password' as reset_url %}
-    {% element form form=form method="post" action=reset_url %}
-        {% slot body %}
-            {% csrf_token %}
-            {% element fields form=form %}
-            {% endelement %}
-        {% endslot %}
-        {% slot actions %}
-            {% element button type="submit" %}
-                {% trans 'Reset My Password' %}
-            {% endelement %}
-        {% endslot %}
-    {% endelement %}
-    <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+      </p>
+
+      {% url 'account_reset_password' as reset_url %}
+
+      {% element form form=form method="post" action=reset_url %}
+          {% slot body %}
+              {% csrf_token %}
+              {% element fields form=form %}
+              {% endelement %}
+          {% endslot %}
+          {% slot actions %}
+              {% element button type="submit" %}
+                  {% trans 'Reset My Password' %}
+              {% endelement %}
+          {% endslot %}
+      {% endelement %}
+
+      <p>
+        {% blocktrans %}
+          Please contact us if you have any trouble resetting your password.
+        {% endblocktrans %}
+      </p>
+    </div>
+  </section>
 {% endblock content %}

--- a/dj_users/templates/account/password_reset_not_logged_in.html
+++ b/dj_users/templates/account/password_reset_not_logged_in.html
@@ -29,11 +29,20 @@
           {% element form form=form method="post" action=reset_url %}
             {% slot body %}
               {% csrf_token %}
-              {% element fields form=form %}
-              {% endelement %}
+
+              {% for error in form.non_field_errors %}
+                <p class="text-red-500 dark:text-red-400">
+                  {{ error }}
+                </p>
+              {% endfor %}
+
+              {% for field in form %}
+                {% include "dj_theme/partials/non_logged_in_forms/field.html" %}
+              {% endfor %}
             {% endslot %}
+
             {% slot actions %}
-              {% element button type="submit" %}
+              {% element button type="submit" tags="prominent,reset" %}
                 {% trans 'Reset My Password' %}
               {% endelement %}
             {% endslot %}

--- a/dj_users/templates/allauth/elements/button.html
+++ b/dj_users/templates/allauth/elements/button.html
@@ -18,6 +18,10 @@
 <button type="submit" class="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">
   {% slot %}{% endslot %}
 </button>
+{% elif "prominent" in attrs.tags and "reset" in attrs.tags %}{# Same as above #}
+<button type="submit" class="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">
+  {% slot %}{% endslot %}
+</button>
 {% else %}
 <{% if attrs.href %}a href="{{ attrs.href }}"{% else %}button{% endif %}
 {% if attrs.form %}form="{{ attrs.form }}"{% endif %}

--- a/dj_users/templates/allauth/elements/form.html
+++ b/dj_users/templates/allauth/elements/form.html
@@ -9,8 +9,15 @@
   </div>
 {% endcomment %}
 
+{% if "authenticated" in attrs.tags  %}
+  <form method="post" action="{{ attrs.action }}" class="space-y-4 max-w-sm mx-auto md:mx-2">
+    {% slot body %}
+    {% endslot %}
 
-{% if "entrance" in attrs.tags and "login" in attrs.tags %}
+    {% slot actions %}
+    {% endslot %}
+  </form>
+{% elif "entrance" in attrs.tags and "login" in attrs.tags %}
   <form method="{{ attrs.method }}" action="{{ attrs.action }}" class="space-y-4 md:space-y-6">
     {% slot body %}
     {% endslot %}

--- a/djforge/settings.py
+++ b/djforge/settings.py
@@ -299,6 +299,19 @@ LOGGING = {
     },
 }
 
+#  ___            _ _    ___           __ _                    _   _
+# | __|_ __  __ _(_) |  / __|___ _ _  / _(_)__ _ _  _ _ _ __ _| |_(_)___ _ _
+# | _|| '  \/ _` | | | | (__/ _ \ ' \|  _| / _` | || | '_/ _` |  _| / _ \ ' \
+# |___|_|_|_\__,_|_|_|  \___\___/_||_|_| |_\__, |\_,_|_| \__,_|\__|_\___/_||_|
+#                                          |___/
+#
+# Email configuration
+#
+# Defaults for development, need to extend for production
+#
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_PORT = env.int("EMAIL_PORT", 1025)
+
 #    _       _   _
 #   /_\ _  _| |_| |_
 #  / _ \ || |  _| ' \

--- a/makefile
+++ b/makefile
@@ -149,7 +149,7 @@ livereload: 			## Run livereload
 # Follow Up(s):
 # - Perhaps add Celery here
 #
-.PHONY: runserver_plus_additional_service
+.PHONY: runserver_plus_additional_services
 runserver_plus_additional_services:	## Run Django server, generate_output_css and livereload together
 	make -j django_runserver generate_output_css livereload
 


### PR DESCRIPTION
Resolves https://github.com/dimitrismistriotis/djforge/issues/91

Aim is not to display links to it as email has not been set up.

- [x] 2x Styling options: authenticated, not-authenticated as we have 2 layouts
- [x] Style for authenticated users
- [x] Propagate includes to password change
- [x] Common include for form errors to theme
- [x] Style for non-authenticated users
- [x] Style `accounts/password/reset/done/`