### PR TITLE
Comment Out Source Map

### DIFF
--- a/dj_theme/static/dj_theme/js/app.bundle.js
+++ b/dj_theme/static/dj_theme/js/app.bundle.js
@@ -5135,4 +5135,12 @@ var dark_mode = __webpack_require__(834);
 
 /******/ })()
 ;
-//# sourceMappingURL=app.bundle.js.map
+/* 
+
+Break sourcmapping as it breaks builds. Can assemble back by bringing everything in one line and removing comments:
+
+//#
+sourceMappingURL
+=
+app.bundle.js.map
+*/


### PR DESCRIPTION
Comment out so that build will not fail:
//# sourceMappingURL=app.bundle.js.map

Instructions there on how to put back